### PR TITLE
Add MUSE_RADIO board config

### DIFF
--- a/components/codec_board/board_cfg.txt
+++ b/components/codec_board/board_cfg.txt
@@ -84,3 +84,8 @@ i2s: {mclk: -1, bclk: 41, ws: 42, dout: -1, din: 2}
 in: {codec: DUMMY, i2c_port: -1}
 sdcard: {clk: 39, cmd: 38, d0: 40}
 camera: {type: dvp, xclk: 15, pclk: 13, vsync: 6, href: 7, d0: 11, d1: 9, d2: 8, d3: 10, d4: 12, d5: 18, d6: 17, d7: 16}
+
+Board: MUSE_RADIO
+i2c: {sda: 18, scl: 11}
+i2s: {mclk: 0, bclk: 5, ws: 16, dout: 17, din: 4}
+in_out: {codec: ES8388, pa: 46, use_mclk: 1, pa_gain:9}

--- a/components/codec_board/codec_init.c
+++ b/components/codec_board/codec_init.c
@@ -78,7 +78,7 @@ static int _i2c_init(uint8_t port)
         ESP_LOGE(TAG, "failed to initialize I2C master bus port %d", port);
         return -1;
     }
-    ESP_LOGI(TAG, "Set mater handle %d %p", port, i2c_bus_handle[port]);
+    ESP_LOGI(TAG, "Set master handle %d %p", port, i2c_bus_handle[port]);
 #else
     i2c_config_t i2c_cfg = {
         .mode = I2C_MODE_MASTER,
@@ -102,7 +102,7 @@ static int _i2c_init(uint8_t port)
 
 void *get_i2c_bus_handle(uint8_t port)
 {
-    ESP_LOGI(TAG, "Get mater handle %d %p", port, i2c_bus_handle[port]);
+    ESP_LOGI(TAG, "Get master handle %d %p", port, i2c_bus_handle[port]);
     return i2c_bus_handle[port];
 }
 
@@ -436,6 +436,19 @@ int init_codec(codec_init_cfg_t *cfg)
                     es7210_cfg.mic_selected |= ES7120_SEL_MIC2 | ES7120_SEL_MIC4;
                 }
                 codec_res.in_codec_if = es7210_codec_new(&es7210_cfg);
+            } break;
+
+            case CODEC_TYPE_ES8388: {
+                i2c_cfg.addr = in_cfg.i2c_addr ? in_cfg.i2c_addr : ES8388_CODEC_DEFAULT_ADDR;
+                codec_res.in_ctrl_if = audio_codec_new_i2c_ctrl(&i2c_cfg);
+                es8388_codec_cfg_t es8388_cfg = {
+                    .codec_mode = same_codec ? ESP_CODEC_DEV_WORK_MODE_BOTH : ESP_CODEC_DEV_WORK_MODE_ADC,
+                    .ctrl_if = codec_res.in_ctrl_if,
+                    .gpio_if = codec_res.gpio_if,
+                    .pa_pin = in_cfg.pa_pin,
+                    .hw_gain.pa_gain = in_cfg.pa_gain,
+                };
+                codec_res.in_codec_if = es8388_codec_new(&es8388_cfg);
             } break;
 
             case CODEC_TYPE_ES7243: {

--- a/solutions/openai_demo/README.md
+++ b/solutions/openai_demo/README.md
@@ -14,7 +14,7 @@ This demo provides functionality similar to the [OpenAI Realtime Embedded SDK](h
 4. **Improved Peer Connection**: Utilizes an enhanced version of `esp_peer` for better performance and reliability.
 
 ## Hardware Requirements
-The default setup uses the [ESP32-S3-Korvo-2](https://docs.espressif.com/projects/esp-adf/en/latest/design-guide/dev-boards/user-guide-esp32-s3-korvo-2.html).
+The default setup uses the **MUSE_RADIO** board.
 
 ## How to build
 

--- a/solutions/openai_demo/main/settings.h
+++ b/solutions/openai_demo/main/settings.h
@@ -19,7 +19,7 @@ extern "C" {
 #if CONFIG_IDF_TARGET_ESP32P4
 #define TEST_BOARD_NAME "ESP32_P4_DEV_V14"
 #else
-#define TEST_BOARD_NAME "S3_Korvo_V2"
+#define TEST_BOARD_NAME "MUSE_RADIO"
 #endif
 
 /**


### PR DESCRIPTION
## Summary
- support MUSE_RADIO board pins and codec
- enable ES8388 codec for input path
- fix typos in log messages
- configure OpenAI example for MUSE_RADIO

## Testing
- `pre-commit run --files components/codec_board/board_cfg.txt components/codec_board/codec_init.c` *(from previous commit)*
- `pre-commit run --files solutions/openai_demo/README.md solutions/openai_demo/main/settings.h`

------
https://chatgpt.com/codex/tasks/task_e_683fef5606a083298b6aeccd66203dbd